### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ This system is released under the GNU Lesser Public License version 3, included 
 
 ## Attribution
 
-This Paillier cryptosystem is a [Daylighting Society](https://daylightingsociety.org) project. Initial version written by Taylor Dahlin and Milo Trujillo, with contributions from Courtney Tambling. This library was inspired by Mike Ivanov's [Paillier](https://github.com/mikeivanov/paillier) library in Python, and began as a language port of that project before being largely rewritten and expanded upon.
+This Paillier cryptosystem is a [Daylighting Society](https://daylightingsociety.org) project. Initial version written by Taylor Dahlin and Milo Trujillo, with contributions from Courtney Tambling, and additional patches from community contributors. This library was inspired by Mike Ivanov's [Paillier](https://github.com/mikeivanov/paillier) library in Python, and began as a language port of that project before being largely rewritten and expanded upon.

--- a/lib/paillier.rb
+++ b/lib/paillier.rb
@@ -98,7 +98,7 @@ module Paillier
 		while( true )
 			# We have to use BigMath here to make sure 'log' doesn't round
 			# to infinity and throw an exception
-			big_n = BigDecimal.new(pub.n)
+			big_n = BigDecimal(pub.n)
 			r = Primes.generateCoprime(BigMath.log(big_n, 2).round, pub.n)
 			if( r > 0 and r < pub.n )
 				break

--- a/lib/paillier/primes.rb
+++ b/lib/paillier/primes.rb
@@ -27,7 +27,7 @@ module Paillier
                 a = 2 + rand(target-4)
                 x = a.to_bn.mod_exp(d, target)
                 next if x == 1 || x == target-1
-                for r in (1..s - 1)
+                (s - 1).times do
                     x = x.to_bn.mod_exp(2, target)
                     return false if x == 1
                     break if x == target - 1

--- a/lib/paillier/zkp.rb
+++ b/lib/paillier/zkp.rb
@@ -48,7 +48,7 @@ module Paillier
 
 				# we generate a random value omega such that omega is coprime to n
 				while( true )
-					big_n = BigDecimal.new( @pubkey.n )
+					big_n = BigDecimal( @pubkey.n )
 					@omega = Primes.generateCoprime(BigMath.log(big_n, 2).round, @pubkey.n)
 					if( @omega > 0 and @omega < @pubkey.n)
 						break
@@ -69,7 +69,7 @@ module Paillier
 					unless ( @p == m_k )
 						# randomly generate a coprime of n for z_k
 						while( true )
-							big_n = BigDecimal::new(@pubkey.n)
+							big_n = BigDecimal(@pubkey.n)
 							z_k = Primes::generateCoprime(BigMath.log(big_n, 2).round, @pubkey.n)
 							if( z_k > 0 and z_k < @pubkey.n )
 								break

--- a/paillier.gemspec
+++ b/paillier.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
 	s.name        = 'paillier'
-	s.version     = '1.2.0'
+	s.version     = '1.2.1'
 	s.date        = '2018-11-10'
 	s.summary     = "Paillier Homomorphic Cryptosystem"
 	s.description = "An implementation of Paillier homomorphic addition public key system"


### PR DESCRIPTION
To remove the following warning messages.

```
Paillier/lib/paillier.rb:101: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
Paillier/lib/paillier/zkp.rb:72: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
Paillier/lib/paillier/zkp.rb:51: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

```
Paillier/lib/paillier/primes.rb:30: warning: assigned but unused variable - r
```

I have checked the test is passed on Ruby 2.4.6, 2.5.3 and 2.6.3.

If this PR is merged, would you release 1.2.1?

Thanks.
