### PR TITLE
fix uninitialized constant Paillier::ZKP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - This CHANGELOG.md file, retroactively written to describe past versions.
 
+### Fixed
+- NameError: uninitialized constant Paillier::ZKP
+
 ## [1.2.1] - 29 June 2019
 ### Changes
 - Updated README.md to include mention of community contributors.

--- a/lib/paillier.rb
+++ b/lib/paillier.rb
@@ -8,6 +8,7 @@ require 'bigdecimal/math' # For 'log'
 require_relative 'paillier/primes'
 require_relative 'paillier/keys'
 require_relative 'paillier/signatures'
+require_relative 'paillier/zkp'
 
 module Paillier
 

--- a/paillier.gemspec
+++ b/paillier.gemspec
@@ -1,12 +1,12 @@
 Gem::Specification.new do |s|
 	s.name        = 'paillier'
-	s.version     = '1.2.1'
+	s.version     = '1.2.2'
 	s.date        = '2018-11-10'
 	s.summary     = "Paillier Homomorphic Cryptosystem"
 	s.description = "An implementation of Paillier homomorphic addition public key system"
 	s.authors     = ["Daylighting Society"]
 	s.email       = 'paillier@daylightingsociety.org'
-	s.files       = ["lib/paillier.rb", "lib/paillier/keys.rb", "lib/paillier/primes.rb", "lib/paillier/signatures.rb"]
+	s.files       = ["lib/paillier.rb", "lib/paillier/keys.rb", "lib/paillier/primes.rb", "lib/paillier/signatures.rb", "lib/paillier/zkp.rb"]
 	s.homepage    = 'https://paillier.daylightingsociety.org'
 	s.license     = 'LGPL-3.0'
 end


### PR DESCRIPTION
When trying to generate Zero-Knowledge Content Proofs, a `uninitialized constant Paillier::ZKP` `NameError` raised.

This PR's fixes it requiring `paillier/zkp` in `lib/paillier.rb`

```rb
>> zkp = Paillier::ZKP.new(pubkey, 65, [23, 38, 52, 65, 77, 94])

NameError: uninitialized constant Paillier::ZKP
```